### PR TITLE
Register/config

### DIFF
--- a/src/driver/imu.rs
+++ b/src/driver/imu.rs
@@ -56,7 +56,7 @@ impl Lsm6ds33<!, !> {
         imu.configure(Ctrl1Xl(OdrXl::DataRate12_5Hz, FsXl::TwoG, BwXl::Bw50Hz))?;
         imu.configure(Ctrl4C(
             XlBwScalOdr::ByBwXl,
-            SleepG::GyroEnable,
+            SleepG::GyroWake,
             Int2OnInt1::Int1AndInt2,
             FifoTempEn::TempDataDisable,
             DrdyMask::DrdyMaskDisable,

--- a/src/driver/imu.rs
+++ b/src/driver/imu.rs
@@ -4,6 +4,8 @@ use embedded_hal::blocking::spi::Transfer;
 use embedded_hal::digital::v2::OutputPin;
 use firmware::update::Update;
 
+mod config;
+
 type SixOf<T> = (T, T, T, T, T, T);
 
 pub enum ImuError<S: Transfer<u8>> {

--- a/src/driver/imu.rs
+++ b/src/driver/imu.rs
@@ -1,8 +1,12 @@
+use config::Register;
 use core::cell::RefCell;
 use core::convert::TryInto;
 use embedded_hal::blocking::spi::Transfer;
 use embedded_hal::digital::v2::OutputPin;
 use firmware::update::Update;
+
+use config::ctrl1xl::*;
+use config::ctrl4c::*;
 
 mod config;
 
@@ -49,8 +53,16 @@ impl Lsm6ds33<!, !> {
         imu.read_bytes(0x0f, &mut buf)?;
 
         // Initialize configuration registers
-        imu.write_bytes(0x10, &[0b_0001_0011])?; // CTRL1_XL
-        imu.write_bytes(0x13, &[0b_1000_0100])?; // CTRL4_C
+        imu.configure(Ctrl1Xl(OdrXl::DataRate12_5Hz, FsXl::TwoG, BwXl::Bw50Hz))?;
+        imu.configure(Ctrl4C(
+            XlBwScalOdr::ByBwXl,
+            SleepG::GyroEnable,
+            Int2OnInt1::Int1AndInt2,
+            FifoTempEn::TempDataDisable,
+            DrdyMask::DrdyMaskDisable,
+            I2cDisable::I2cDisable,
+            StopOnFth::FifoDepthUnlimited,
+        ))?;
 
         match buf {
             [0x69] => Ok(imu),
@@ -100,6 +112,11 @@ impl<S: Transfer<u8>, C: OutputPin> Lsm6ds33<S, C> {
         buf[0] = addr & 0b_0111_1111;
         buf[1..].copy_from_slice(input);
         self.transfer(buf)?;
+        Ok(())
+    }
+
+    pub fn configure<R: Register>(&mut self, register: R) -> Result<(), ImuError<S>> {
+        self.write_bytes(register.address(), &[register.value()])?;
         Ok(())
     }
 }

--- a/src/driver/imu/config.rs
+++ b/src/driver/imu/config.rs
@@ -1,6 +1,7 @@
 pub mod ctrl1xl;
+pub mod ctrl4c;
 
-trait Register {
+pub trait Register {
     fn address(&self) -> u8;
     fn value(&self) -> u8;
 }

--- a/src/driver/imu/config.rs
+++ b/src/driver/imu/config.rs
@@ -1,0 +1,11 @@
+pub mod ctrl1xl;
+
+trait Register {
+    fn address(&self) -> u8;
+    fn value(&self) -> u8;
+}
+
+trait RegisterSetting {
+    fn mask(&self) -> u8;
+    fn value(&self) -> u8;
+}

--- a/src/driver/imu/config/ctrl1xl.rs
+++ b/src/driver/imu/config/ctrl1xl.rs
@@ -1,0 +1,133 @@
+use super::{Register, RegisterSetting};
+
+/// Linear acceleration sensor control register 1 (r/w).
+pub struct Ctrl1Xl(OdrXl, FsXl, BwXl);
+
+impl Register for Ctrl1Xl {
+    fn address(&self) -> u8 {
+        0x10
+    }
+
+    fn value(&self) -> u8 {
+        let Self(odrxl, fsxl, bwxl) = self;
+
+        odrxl.value() | fsxl.value() | bwxl.value()
+    }
+}
+
+/// Output data rate and power mode selection.
+pub enum OdrXl {
+    /// Power-down
+    PowerDown,
+
+    /// 12.5 Hz
+    DataRate12_5Hz,
+
+    /// 26 Hz
+    DataRate26Hz,
+
+    /// 52 Hz
+    DataRate52Hz,
+
+    /// 104 Hz
+    DataRate104Hz,
+
+    /// 208 Hz
+    DataRate208Hz,
+
+    /// 416 Hz
+    DataRate416Hz,
+
+    /// 833 Hz
+    DataRate833Hz,
+
+    /// 1.66 kHz
+    DataRate1_66Khz,
+
+    /// 3.33 kHz
+    DataRate3_33Khz,
+
+    /// 6.66 kHz
+    DataRate6_66Khz,
+}
+
+impl RegisterSetting for OdrXl {
+    fn value(&self) -> u8 {
+        match self {
+            Self::PowerDown => 0b_0000_0000,
+            Self::DataRate12_5Hz => 0b_0001_0000,
+            Self::DataRate26Hz => 0b_0010_0000,
+            Self::DataRate52Hz => 0b_0011_0000,
+            Self::DataRate104Hz => 0b_0100_0000,
+            Self::DataRate208Hz => 0b_0101_0000,
+            Self::DataRate416Hz => 0b_0110_0000,
+            Self::DataRate833Hz => 0b_0111_0000,
+            Self::DataRate1_66Khz => 0b_1000_0000,
+            Self::DataRate3_33Khz => 0b_1001_0000,
+            Self::DataRate6_66Khz => 0b_1010_0000,
+        }
+    }
+
+    fn mask(&self) -> u8 {
+        0b_1111_0000
+    }
+}
+
+/// Accelerometer full-scale selection.
+pub enum FsXl {
+    /// ±2g
+    TwoG,
+
+    /// ±4g
+    FourG,
+
+    /// ±8g
+    EightG,
+
+    /// ±16g
+    SixteenG,
+}
+
+impl RegisterSetting for FsXl {
+    fn value(&self) -> u8 {
+        match self {
+            Self::TwoG => 0b_0000_0000,
+            Self::FourG => 0b_0000_1000,
+            Self::EightG => 0b_0000_1100,
+            Self::SixteenG => 0b_0000_0100,
+        }
+    }
+
+    fn mask(&self) -> u8 {
+        0b_0000_1100
+    }
+}
+/// Anti-aliasing filter bandwidth selection.
+pub enum BwXl {
+    /// 50 Hz
+    Bw50Hz,
+
+    /// 100 Hz
+    Bw100Hz,
+
+    /// 200 Hz
+    Bw200Hz,
+
+    /// 400 Hz
+    Bw400Hz,
+}
+
+impl RegisterSetting for BwXl {
+    fn value(&self) -> u8 {
+        match self {
+            Self::Bw50Hz => 0b_0000_0011,
+            Self::Bw100Hz => 0b_0000_0010,
+            Self::Bw200Hz => 0b_0000_0001,
+            Self::Bw400Hz => 0b_0000_0000,
+        }
+    }
+
+    fn mask(&self) -> u8 {
+        0b_0000_0011
+    }
+}

--- a/src/driver/imu/config/ctrl1xl.rs
+++ b/src/driver/imu/config/ctrl1xl.rs
@@ -1,7 +1,7 @@
 use super::{Register, RegisterSetting};
 
 /// Linear acceleration sensor control register 1 (r/w).
-pub struct Ctrl1Xl(OdrXl, FsXl, BwXl);
+pub struct Ctrl1Xl(pub OdrXl, pub FsXl, pub BwXl);
 
 impl Register for Ctrl1Xl {
     fn address(&self) -> u8 {

--- a/src/driver/imu/config/ctrl4c.rs
+++ b/src/driver/imu/config/ctrl4c.rs
@@ -51,17 +51,17 @@ impl RegisterSetting for XlBwScalOdr {
 
 pub enum SleepG {
     /// Gyroscope sleep mode enabled
-    GyroEnable,
+    GyroWake,
 
     /// Gyroscope sleep mode disabled
-    GyroDisable,
+    GyroSleep,
 }
 
 impl RegisterSetting for SleepG {
     fn value(&self) -> u8 {
         match self {
-            Self::GyroEnable => 0b_0000_0000,
-            Self::GyroDisable => 0b_0100_0000,
+            Self::GyroWake => 0b_0000_0000,
+            Self::GyroSleep => 0b_0100_0000,
         }
     }
     fn mask(&self) -> u8 {

--- a/src/driver/imu/config/ctrl4c.rs
+++ b/src/driver/imu/config/ctrl4c.rs
@@ -1,0 +1,25 @@
+use super::{Register, RegisterSetting};
+
+pub struct Ctrl4C(
+    XlBwScalOdr,
+    SleepG,
+    Int2OnInt1,
+    FifoTempEn,
+    DrdyMask,
+    I2cDisable,
+    StopOnFth,
+);
+
+pub enum XlBwScalOdr {}
+
+pub enum SleepG {}
+
+pub enum Int2OnInt1 {}
+
+pub enum FifoTempEn {}
+
+pub enum DrdyMask {}
+
+pub enum I2cDisable {}
+
+pub enum StopOnFth {}

--- a/src/driver/imu/config/ctrl4c.rs
+++ b/src/driver/imu/config/ctrl4c.rs
@@ -50,10 +50,10 @@ impl RegisterSetting for XlBwScalOdr {
 }
 
 pub enum SleepG {
-    /// Gyroscope sleep mode enabled
+    /// Gyroscope sleep mode disabled
     GyroWake,
 
-    /// Gyroscope sleep mode disabled
+    /// Gyroscope sleep mode enabled
     GyroSleep,
 }
 

--- a/src/driver/imu/config/ctrl4c.rs
+++ b/src/driver/imu/config/ctrl4c.rs
@@ -1,25 +1,177 @@
 use super::{Register, RegisterSetting};
 
 pub struct Ctrl4C(
-    XlBwScalOdr,
-    SleepG,
-    Int2OnInt1,
-    FifoTempEn,
-    DrdyMask,
-    I2cDisable,
-    StopOnFth,
+    pub XlBwScalOdr,
+    pub SleepG,
+    pub Int2OnInt1,
+    pub FifoTempEn,
+    pub DrdyMask,
+    pub I2cDisable,
+    pub StopOnFth,
 );
 
-pub enum XlBwScalOdr {}
+impl Register for Ctrl4C {
+    fn address(&self) -> u8 {
+        0x13
+    }
 
-pub enum SleepG {}
+    fn value(&self) -> u8 {
+        let Self(xlbwscalodr, sleepg, int2onint1, fifotempen, drdymask, i2cdisable, stoponfth) =
+            self;
 
-pub enum Int2OnInt1 {}
+        xlbwscalodr.value()
+            | sleepg.value()
+            | int2onint1.value()
+            | fifotempen.value()
+            | drdymask.value()
+            | i2cdisable.value()
+            | stoponfth.value()
+    }
+}
 
-pub enum FifoTempEn {}
+pub enum XlBwScalOdr {
+    /// Bandwidth determined by ODR selection
+    ByOdr,
 
-pub enum DrdyMask {}
+    /// Bandwidth determined by setting [`BwXl`] in [`Ctrl1Xl`](super::ctrl1xl::Ctrl1Xl)
+    ByBwXl,
+}
 
-pub enum I2cDisable {}
+impl RegisterSetting for XlBwScalOdr {
+    fn value(&self) -> u8 {
+        match self {
+            Self::ByOdr => 0b_0000_0000,
+            Self::ByBwXl => 0b_1000_0000,
+        }
+    }
+    fn mask(&self) -> u8 {
+        0b_1000_0000
+    }
+}
 
-pub enum StopOnFth {}
+pub enum SleepG {
+    /// Gyroscope sleep mode enabled
+    GyroEnable,
+
+    /// Gyroscope sleep mode disabled
+    GyroDisable,
+}
+
+impl RegisterSetting for SleepG {
+    fn value(&self) -> u8 {
+        match self {
+            Self::GyroEnable => 0b_0000_0000,
+            Self::GyroDisable => 0b_0100_0000,
+        }
+    }
+    fn mask(&self) -> u8 {
+        0b_0100_0000
+    }
+}
+
+pub enum Int2OnInt1 {
+    /// all interrupt signals in logic or on INT1 pad
+    Int1Only,
+
+    /// interrupt signals divided between INT1 and INT2 pads;
+    Int1AndInt2,
+}
+
+impl RegisterSetting for Int2OnInt1 {
+    fn value(&self) -> u8 {
+        match self {
+            Self::Int1AndInt2 => 0b_0000_0000,
+            Self::Int1Only => 0b_0010_0000,
+        }
+    }
+    fn mask(&self) -> u8 {
+        0b_0010_0000
+    }
+}
+
+/// Enable temperature data as 3rd FIFO data set
+pub enum FifoTempEn {
+    /// enable temperature data as 3rd FIFO data set
+    TempDataEnable,
+
+    /// disable temperature data as 3rd FIFO data set
+    TempDataDisable,
+}
+
+impl RegisterSetting for FifoTempEn {
+    fn value(&self) -> u8 {
+        match self {
+            Self::TempDataDisable => 0b_0000_0000,
+            Self::TempDataEnable => 0b_0001_0000,
+        }
+    }
+
+    fn mask(&self) -> u8 {
+        0b_0001_0000
+    }
+}
+
+/// Data-ready mask enable. If enabled, when switching from Power-Down to an active mode,
+/// the accelerometer and gyroscope data-ready signals are masked until the settling of the sensor
+/// filters is completed
+pub enum DrdyMask {
+    /// Data-ready mask enable
+    DrdyMaskEnable,
+
+    /// Data-ready mask disable
+    DrdyMaskDisable,
+}
+
+impl RegisterSetting for DrdyMask {
+    fn value(&self) -> u8 {
+        match self {
+            Self::DrdyMaskDisable => 0b_0000_0000,
+            Self::DrdyMaskEnable => 0b_0000_1000,
+        }
+    }
+    fn mask(&self) -> u8 {
+        0b_0000_1000
+    }
+}
+
+/// Disable I2C interface
+pub enum I2cDisable {
+    /// both I2C and SPI enabled
+    I2cEnable,
+
+    /// I2C disabled, SPI only
+    I2cDisable,
+}
+
+impl RegisterSetting for I2cDisable {
+    fn value(&self) -> u8 {
+        match self {
+            Self::I2cEnable => 0b_0000_0000,
+            Self::I2cDisable => 0b_0000_0100,
+        }
+    }
+    fn mask(&self) -> u8 {
+        0b_0000_0100
+    }
+}
+
+/// Enable FIFO threshold level use.
+pub enum StopOnFth {
+    /// FIFO depth is limited to threshold level
+    FifoDepthLimitedByThreshold,
+
+    /// FIFO depth is not limited
+    FifoDepthUnlimited,
+}
+
+impl RegisterSetting for StopOnFth {
+    fn value(&self) -> u8 {
+        match self {
+            Self::FifoDepthUnlimited => 0b_0000_0000,
+            Self::FifoDepthLimitedByThreshold => 0b_0000_0001,
+        }
+    }
+    fn mask(&self) -> u8 {
+        0b_0000_0001
+    }
+}


### PR DESCRIPTION
Add a `configure` function to `lsm6ds33` 
Break `Ctrl1Xl` and `Ctrl4C` registers into individual settings. 
Refactor init step to use new `configure` function
